### PR TITLE
Update extension.js

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,6 @@
 const St = imports.gi.St;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
+const Tweener = imports.tweener.tweener;
 const DELAY = 2; // seconds to travel the screen width
 const COUNT = 8; // number of objects
 


### PR DESCRIPTION
At least in Gnome 3.38, the import for the Tweener library got moved from "imports.ui.tweener" to "imports.tweener.tweener" (see https://askubuntu.com/questions/1286212/no-js-module-tweener-found-in-search-path-gnome-shell-extension-error-on-ubun).

I updated this import via this merge request